### PR TITLE
allow exporting number of RPC calls per method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.5.6
+* Feature that allows measuring number of RPC calls via an adapter https://github.com/mana-ethereum/ethereumex/pull/67
+
 # 0.5.5
 * Allow request counter resetting (https://github.com/mana-ethereum/ethereumex/pull/65)
 

--- a/README.md
+++ b/README.md
@@ -61,13 +61,17 @@ config :ethereumex,
 ```
 
 If you want to count the number of RPC calls per RPC method,
-set adapter in the configuration. The adapter needs to implement `increment/2`
-where the first argument is the key, the second in the count integer.
+set adapter in the configuration. The adapter needs to implement `increment/3`
+where the first argument is the key, the second is an integer and the third are optional keyword options you
+want to pass to your adapter on each increment call.
 
 ```elixir
 config :ethereumex,
   adapter: Datadog
+  adapter_options: []
 ```
+An example of an adapter would be [Statix](https://github.com/lexmag/statix/blob/v1.2.1/lib/statix.ex#L288-L290).
+Adapter options could be `[sample_rate: 1.0, tags: ["foo", "bar"]]`.
 
 The IPC client type mode opens a pool of connection workers (default is 5 and 2, respectively). You can configure the pool size.
 ```elixir

--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ config :ethereumex,
   ipc_path: "/path/to/ipc"
 ```
 
+If you want to count the number of RPC calls per RPC method,
+set adapter in the configuration. The adapter needs to implement `increment/2`
+where the first argument is the key, the second in the count integer.
+
+```elixir
+config :ethereumex,
+  adapter: Datadog
+```
+
 The IPC client type mode opens a pool of connection workers (default is 5 and 2, respectively). You can configure the pool size.
 ```elixir
 config :ethereumex,

--- a/lib/ethereumex/client/base_client.ex
+++ b/lib/ethereumex/client/base_client.ex
@@ -487,20 +487,22 @@ defmodule Ethereumex.Client.BaseClient do
       end
 
       defp prepare_request(params) when is_list(params) do
-        id = Counter.increment(:rpc_counter)
+        id = Counter.get(:rpc_counter)
 
         params =
           params
-          |> Enum.with_index()
+          |> Enum.with_index(1)
           |> Enum.map(fn {req_data, index} ->
             Map.put(req_data, "id", index + id)
           end)
 
-        _ = Counter.increment(:rpc_counter, id + Enum.count(params))
+        _ = Counter.increment(:rpc_counter, id + Enum.count(params), "eth_batch")
+
         params
       end
 
-      defp prepare_request(params), do: Map.put(params, "id", Counter.increment(:rpc_counter))
+      defp prepare_request(params),
+        do: Map.put(params, "id", Counter.increment(:rpc_counter, params["method"]))
 
       defp request(params, opts) do
         __MODULE__.single_request(params, opts)

--- a/lib/ethereumex/counter.ex
+++ b/lib/ethereumex/counter.ex
@@ -60,7 +60,7 @@ defmodule Ethereumex.Counter do
   end
 
   defp inc(key, method, adapter) do
-    _ = adapter.increment(method, 1)
+    _ = adapter.increment(method, 1, Application.get_env(:ethereumex, :adapter_options) || [])
     :ets.update_counter(@tab, key, {2, 1}, {key, 0})
   end
 
@@ -69,7 +69,7 @@ defmodule Ethereumex.Counter do
   end
 
   defp inc(key, count, method, adapter) do
-    _ = adapter.increment(method, 1)
+    _ = adapter.increment(method, 1, Application.get_env(:ethereumex, :adapter_options) || [])
     :ets.update_counter(@tab, key, {2, count}, {key, 0})
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ethereumex.Mixfile do
   def project do
     [
       app: :ethereumex,
-      version: "0.5.5",
+      version: "0.5.6",
       elixir: "~> 1.7",
       description: "Elixir JSON-RPC client for the Ethereum blockchain",
       package: [

--- a/test/ethereumex/counter_reset_test.exs
+++ b/test/ethereumex/counter_reset_test.exs
@@ -11,18 +11,18 @@ defmodule Ethereumex.ResetLockTest do
   end
 
   test "incrementing twice returns correct locked binary" do
-    1 = Counter.increment(:test_11)
-    1 = Counter.increment(:test_11)
+    1 = Counter.increment(:test_11, "method_11")
+    1 = Counter.increment(:test_11, "method_11")
   end
 
   test "incrementing twice and updating with a count returns correct locked binary" do
-    1 = Counter.increment(:test_22)
-    2 = Counter.increment(:test_22, 2)
+    1 = Counter.increment(:test_22, "method_22")
+    2 = Counter.increment(:test_22, 2, "method_22")
   end
 
   test "incrementing twice, updating with a count and incrementing again returns correct locked binary" do
-    1 = Counter.increment(:test_33)
-    2 = Counter.increment(:test_33, 2)
-    1 = Counter.increment(:test_33)
+    1 = Counter.increment(:test_33, "method_33")
+    2 = Counter.increment(:test_33, 2, "method_33")
+    1 = Counter.increment(:test_33, "method_33")
   end
 end

--- a/test/ethereumex/counter_test.exs
+++ b/test/ethereumex/counter_test.exs
@@ -2,21 +2,38 @@ defmodule Ethereumex.CounterTest do
   use ExUnit.Case
   alias Ethereumex.Counter
 
+  setup_all do
+    on_exit(fn -> Application.put_env(:ethereumex, :adapter, nil) end)
+    :ok
+  end
+
   test "incrementing twice returns correct number" do
-    1 = Counter.increment(:test_1)
-    2 = Counter.increment(:test_1)
+    1 = Counter.increment(:test_1, "method_1")
+    2 = Counter.increment(:test_1, "method_1")
   end
 
   test "incrementing twice and updating with a count returns correct number" do
-    1 = Counter.increment(:test_2)
-    2 = Counter.increment(:test_2)
-    4 = Counter.increment(:test_2, 2)
+    1 = Counter.increment(:test_2, "method_2")
+    2 = Counter.increment(:test_2, "method_2")
+    4 = Counter.increment(:test_2, 2, ["method_2"])
   end
 
   test "incrementing twice, updating with a count and incrementing again returns correct number" do
-    1 = Counter.increment(:test_3)
-    2 = Counter.increment(:test_3)
-    4 = Counter.increment(:test_3, 2)
-    5 = Counter.increment(:test_3)
+    1 = Counter.increment(:test_3, "method_3")
+    2 = Counter.increment(:test_3, "method_3")
+    4 = Counter.increment(:test_3, 2, ["method_3"])
+    5 = Counter.increment(:test_3, "method_3")
+  end
+
+  test "an adapter gets called with increment/2" do
+    :ok = Application.put_env(:ethereumex, :adapter, __MODULE__.Adapter)
+    1 = Counter.increment(:test_4, "method_4")
+    assert_receive({"method_4", 1})
+    3 = Counter.increment(:test_4, 2, "eth_batch")
+    assert_receive({"eth_batch", 1})
+  end
+
+  defmodule Adapter do
+    def increment(method, count), do: Kernel.send(self(), {method, count})
   end
 end

--- a/test/ethereumex/counter_test.exs
+++ b/test/ethereumex/counter_test.exs
@@ -3,7 +3,11 @@ defmodule Ethereumex.CounterTest do
   alias Ethereumex.Counter
 
   setup_all do
-    on_exit(fn -> Application.put_env(:ethereumex, :adapter, nil) end)
+    on_exit(fn ->
+      Application.put_env(:ethereumex, :adapter, nil)
+      Application.put_env(:ethereumex, :adapter_options, nil)
+    end)
+
     :ok
   end
 
@@ -28,12 +32,16 @@ defmodule Ethereumex.CounterTest do
   test "an adapter gets called with increment/2" do
     :ok = Application.put_env(:ethereumex, :adapter, __MODULE__.Adapter)
     1 = Counter.increment(:test_4, "method_4")
-    assert_receive({"method_4", 1})
+    assert_receive({"method_4", 1, []})
     3 = Counter.increment(:test_4, 2, "eth_batch")
-    assert_receive({"eth_batch", 1})
+    assert_receive({"eth_batch", 1, []})
+
+    :ok = Application.put_env(:ethereumex, :adapter_options, sample_rate: 0.5)
+    5 = Counter.increment(:test_4, 2, "eth_batch")
+    assert_receive({"eth_batch", 1, [sample_rate: 0.5]})
   end
 
   defmodule Adapter do
-    def increment(method, count), do: Kernel.send(self(), {method, count})
+    def increment(method, count, options), do: Kernel.send(self(), {method, count, options})
   end
 end


### PR DESCRIPTION
<img width="1078" alt="Screen Shot 2020-02-27 at 23 16 48" src="https://user-images.githubusercontent.com/2582555/75492064-42a1ab00-59b7-11ea-8a52-80bebaeef1df.png">

We use this to set the adapter to Datadog and that allows us to measure and plot the number of RPC calls we make.