### PR TITLE
Fix rpc_counter exponentially increases with batch requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
-# 0.6.3
+# 0.6.4
 * Fix request id exhaustion due to exponential increment (https://github.com/mana-ethereum/ethereumex/pull/76)
+
+# 0.6.3
 * Make batch requests support configurable url via opts argument (https://github.com/mana-ethereum/ethereumex/pull/77)
 
 # 0.6.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.6.3
+* Fix request id exhaustion due to exponential increment (https://github.com/mana-ethereum/ethereumex/pull/76)
+
 # 0.6.2
 * Make `telemetry` required dependency (https://github.com/mana-ethereum/ethereumex/pull/73)
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add Ethereumex to your `mix.exs` dependencies:
 1. Add `ethereumex` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
-  [{:ethereumex, "~> 0.6.3"}]
+  [{:ethereumex, "~> 0.6.4"}]
 end
 ```
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add Ethereumex to your `mix.exs` dependencies:
 1. Add `ethereumex` to your list of dependencies in `mix.exs`:
 ```elixir
 def deps do
-  [{:ethereumex, "~> 0.6.1"}]
+  [{:ethereumex, "~> 0.6.3"}]
 end
 ```
 

--- a/lib/ethereumex/client/base_client.ex
+++ b/lib/ethereumex/client/base_client.ex
@@ -496,7 +496,7 @@ defmodule Ethereumex.Client.BaseClient do
             Map.put(req_data, "id", index + id)
           end)
 
-        _ = Counter.increment(:rpc_counter, id + Enum.count(params), "eth_batch")
+        _ = Counter.increment(:rpc_counter, Enum.count(params), "eth_batch")
 
         params
       end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ethereumex.Mixfile do
   def project do
     [
       app: :ethereumex,
-      version: "0.6.2",
+      version: "0.6.3",
       elixir: "~> 1.7",
       description: "Elixir JSON-RPC client for the Ethereum blockchain",
       package: [

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ethereumex.Mixfile do
   def project do
     [
       app: :ethereumex,
-      version: "0.6.3",
+      version: "0.6.4",
       elixir: "~> 1.7",
       description: "Elixir JSON-RPC client for the Ethereum blockchain",
       package: [


### PR DESCRIPTION
Fixes the rpc_counter incrementing by current counter + current batch's requests, causing the id to grow exponentially and exhaust very rapidly.

For example, a constant 10 requests/batch reached `uint64`'s limit of `18446744073709551615` within ~65 requests, with previous batch's last successful request at `id: 12105675798371893248` and the subsequent batch's first failure at `id: 24211351596743786487`.

This happens because `Counter.increment/3` should be passed just the batch count, but it's currently passed `current_id + batch_count`.