### PR TITLE
Remove unremovable default hackney pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,12 @@ config :ethereumex,
 ```
 
 You can also configure the `HTTP` request timeout for requests sent to the Ethereum JSON-RPC
-(you can also overwrite this configuration in `opts` used when calling the client):
+(you can also overwrite this configuration in `opts` used when calling the client). By default
+http requests use no pools, if you want to use hackney default http request pool:
 
 ```elixir
 config :ethereumex,
-  http_options: [timeout: 8000, recv_timeout: 5000]
+  http_options: [timeout: 8000, recv_timeout: 5000, hackney: [pool: :default]]
 
 ```
 :timeout - timeout to establish a connection, in milliseconds. Default is 8000

--- a/lib/ethereumex/http_client.ex
+++ b/lib/ethereumex/http_client.ex
@@ -7,10 +7,9 @@ defmodule Ethereumex.HttpClient do
   @spec post_request(binary(), []) :: {:ok | :error, any()}
   def post_request(payload, opts) do
     headers = [{"Content-Type", "application/json"}]
-    options = [hackney: [pool: :default]] ++ Config.http_options()
     url = Keyword.get(opts, :url) || Config.rpc_url()
 
-    case HTTPoison.post(url, payload, headers, options) do
+    case HTTPoison.post(url, payload, headers, Config.http_options()) do
       {:ok, response} ->
         %HTTPoison.Response{body: body, status_code: code} = response
         decode_body(body, code)


### PR DESCRIPTION
This was needed, because my tests were failing due to this new default hackney pool usage that was not removable from outside. https://github.com/mana-ethereum/ethereumex/issues/81

NOTE: we should cut a MINOR release afterwards as this is a breaking change.