### PR TITLE
Config.setup_children can inject client type

### DIFF
--- a/lib/ethereumex/config.ex
+++ b/lib/ethereumex/config.ex
@@ -2,39 +2,26 @@ defmodule Ethereumex.Config do
   @moduledoc false
   alias Ethereumex.IpcServer
 
-  def setup_children() do
-    setup_children(client_type())
+  def setup_children(type \\ client_type()) do
+    case type do
+      :ipc ->
+        [
+          :poolboy.child_spec(:worker, poolboy_config(),
+            path: Enum.join([System.user_home!(), ipc_path()]),
+            ipc_request_timeout: ipc_request_timeout()
+          )
+        ]
+
+      :http ->
+        []
+
+      opt ->
+        raise "Invalid :client option (#{opt}) in config"
+    end
   end
 
-  defp setup_children(:ipc) do
-    path = Enum.join([System.user_home!(), ipc_path()])
-
-    [
-      :poolboy.child_spec(:worker, poolboy_config(),
-        path: path,
-        ipc_request_timeout: ipc_request_timeout()
-      )
-    ]
-  end
-
-  defp setup_children(:http), do: []
-
-  defp setup_children(opt) do
-    raise "Invalid :client option (#{opt}) in config"
-  end
-
-  @spec poolboy_config() :: keyword()
-  defp poolboy_config() do
-    [
-      {:name, {:local, :ipc_worker}},
-      {:worker_module, IpcServer},
-      {:size, ipc_worker_size()},
-      {:max_overflow, ipc_max_worker_overflow()}
-    ]
-  end
-
-  @spec rpc_url() :: binary()
-  def rpc_url() do
+  @spec rpc_url() :: binary
+  def rpc_url do
     case Application.get_env(:ethereumex, :url) do
       url when is_binary(url) and url != "" ->
         url
@@ -44,22 +31,12 @@ defmodule Ethereumex.Config do
           message:
             "Please set config variable `config :ethereumex, :url, \"http://...\", got: `#{
               inspect(els)
-            }``"
+            }`"
     end
   end
 
-  @spec http_options() :: keyword()
-  def http_options() do
-    Application.get_env(:ethereumex, :http_options, [])
-  end
-
-  @spec client_type() :: atom()
-  def client_type() do
-    Application.get_env(:ethereumex, :client_type, :http)
-  end
-
-  @spec ipc_path() :: binary()
-  def ipc_path() do
+  @spec ipc_path() :: binary
+  def ipc_path do
     case Application.get_env(:ethereumex, :ipc_path, "") do
       path when is_binary(path) and path != "" ->
         path
@@ -73,18 +50,38 @@ defmodule Ethereumex.Config do
     end
   end
 
-  @spec ipc_worker_size() :: integer()
-  defp ipc_worker_size() do
+  @spec http_options() :: keyword
+  def http_options do
+    Application.get_env(:ethereumex, :http_options, [])
+  end
+
+  @spec client_type() :: atom
+  def client_type do
+    Application.get_env(:ethereumex, :client_type, :http)
+  end
+
+  @spec poolboy_config() :: keyword
+  defp poolboy_config do
+    [
+      {:name, {:local, :ipc_worker}},
+      {:worker_module, IpcServer},
+      {:size, ipc_worker_size()},
+      {:max_overflow, ipc_max_worker_overflow()}
+    ]
+  end
+
+  @spec ipc_worker_size() :: integer
+  defp ipc_worker_size do
     Application.get_env(:ethereumex, :ipc_worker_size, 5)
   end
 
-  @spec ipc_max_worker_overflow() :: integer()
-  defp ipc_max_worker_overflow() do
+  @spec ipc_max_worker_overflow() :: integer
+  defp ipc_max_worker_overflow do
     Application.get_env(:ethereumex, :ipc_max_worker_overflow, 2)
   end
 
-  @spec ipc_request_timeout() :: integer()
-  defp ipc_request_timeout() do
+  @spec ipc_request_timeout() :: integer
+  defp ipc_request_timeout do
     Application.get_env(:ethereumex, :ipc_request_timeout, 60_000)
   end
 end

--- a/lib/ethereumex/config.ex
+++ b/lib/ethereumex/config.ex
@@ -2,23 +2,19 @@ defmodule Ethereumex.Config do
   @moduledoc false
   alias Ethereumex.IpcServer
 
-  def setup_children(type \\ client_type()) do
-    case type do
-      :ipc ->
-        [
-          :poolboy.child_spec(:worker, poolboy_config(),
-            path: Enum.join([System.user_home!(), ipc_path()]),
-            ipc_request_timeout: ipc_request_timeout()
-          )
-        ]
+  def setup_children(), do: setup_children(client_type())
 
-      :http ->
-        []
-
-      opt ->
-        raise "Invalid :client option (#{opt}) in config"
-    end
+  def setup_children(:ipc) do
+    [
+      :poolboy.child_spec(:worker, poolboy_config(),
+        path: Enum.join([System.user_home!(), ipc_path()]),
+        ipc_request_timeout: ipc_request_timeout()
+      )
+    ]
   end
+
+  def setup_children(:http), do: []
+  def setup_children(opt), do: raise("Invalid :client option (#{opt}) in config")
 
   @spec rpc_url() :: binary()
   def rpc_url() do

--- a/lib/ethereumex/config.ex
+++ b/lib/ethereumex/config.ex
@@ -20,8 +20,8 @@ defmodule Ethereumex.Config do
     end
   end
 
-  @spec rpc_url() :: binary
-  def rpc_url do
+  @spec rpc_url() :: binary()
+  def rpc_url() do
     case Application.get_env(:ethereumex, :url) do
       url when is_binary(url) and url != "" ->
         url
@@ -35,8 +35,8 @@ defmodule Ethereumex.Config do
     end
   end
 
-  @spec ipc_path() :: binary
-  def ipc_path do
+  @spec ipc_path() :: binary()
+  def ipc_path() do
     case Application.get_env(:ethereumex, :ipc_path, "") do
       path when is_binary(path) and path != "" ->
         path
@@ -50,18 +50,18 @@ defmodule Ethereumex.Config do
     end
   end
 
-  @spec http_options() :: keyword
-  def http_options do
+  @spec http_options() :: keyword()
+  def http_options() do
     Application.get_env(:ethereumex, :http_options, [])
   end
 
-  @spec client_type() :: atom
-  def client_type do
+  @spec client_type() :: atom()
+  def client_type() do
     Application.get_env(:ethereumex, :client_type, :http)
   end
 
-  @spec poolboy_config() :: keyword
-  defp poolboy_config do
+  @spec poolboy_config() :: keyword()
+  defp poolboy_config() do
     [
       {:name, {:local, :ipc_worker}},
       {:worker_module, IpcServer},
@@ -70,18 +70,18 @@ defmodule Ethereumex.Config do
     ]
   end
 
-  @spec ipc_worker_size() :: integer
-  defp ipc_worker_size do
+  @spec ipc_worker_size() :: integer()
+  defp ipc_worker_size() do
     Application.get_env(:ethereumex, :ipc_worker_size, 5)
   end
 
-  @spec ipc_max_worker_overflow() :: integer
-  defp ipc_max_worker_overflow do
+  @spec ipc_max_worker_overflow() :: integer()
+  defp ipc_max_worker_overflow() do
     Application.get_env(:ethereumex, :ipc_max_worker_overflow, 2)
   end
 
-  @spec ipc_request_timeout() :: integer
-  defp ipc_request_timeout do
+  @spec ipc_request_timeout() :: integer()
+  defp ipc_request_timeout() do
     Application.get_env(:ethereumex, :ipc_request_timeout, 60_000)
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -42,7 +42,8 @@ defmodule Ethereumex.Mixfile do
       {:ex_doc, "~> 0.21", only: :dev, runtime: false},
       {:dialyxir, "~> 1.0", only: [:dev, :test], runtime: false},
       {:poolboy, "~> 1.5.1"},
-      {:telemetry, "~> 0.4"}
+      {:telemetry, "~> 0.4"},
+      {:with_env, "~> 0.1", only: :test}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -20,4 +20,5 @@
   "ssl_verify_fun": {:hex, :ssl_verify_fun, "1.1.5", "6eaf7ad16cb568bb01753dbbd7a95ff8b91c7979482b95f38443fe2c8852a79b", [:make, :mix, :rebar3], [], "hexpm", "13104d7897e38ed7f044c4de953a6c28597d1c952075eb2e328bc6d6f2bfc496"},
   "telemetry": {:hex, :telemetry, "0.4.1", "ae2718484892448a24470e6aa341bc847c3277bfb8d4e9289f7474d752c09c7f", [:rebar3], [], "hexpm", "4738382e36a0a9a2b6e25d67c960e40e1a2c95560b9f936d8e29de8cd858480f"},
   "unicode_util_compat": {:hex, :unicode_util_compat, "0.4.1", "d869e4c68901dd9531385bb0c8c40444ebf624e60b6962d95952775cac5e90cd", [:rebar3], [], "hexpm", "1d1848c40487cdb0b30e8ed975e34e025860c02e419cb615d255849f3427439d"},
+  "with_env": {:hex, :with_env, "0.1.0", "4c4d4bdf54733917945fa0c521b7a7bbad4f4c65ce75b346a566695898a4f59a", [:mix], [], "hexpm", "2345cf474a963184edb23f626b4f498472c7d9fe5aa2c71473981dc054bdef95"},
 }

--- a/test/ethereumex/config_test.exs
+++ b/test/ethereumex/config_test.exs
@@ -1,0 +1,118 @@
+defmodule Ethereumex.ConfigTest do
+  use ExUnit.Case
+  use WithEnv
+
+  describe ".setup_children" do
+    test ":ipc returns a list with 1 worker pool" do
+      with_env put: [
+                 ethereumex: [
+                   ipc_worker_size: 3,
+                   ipc_max_worker_overflow: 4,
+                   ipc_request_timeout: 5,
+                   ipc_path: "/tmp/socket.ipc"
+                 ]
+               ] do
+        specs = Ethereumex.Config.setup_children(:ipc)
+
+        assert Enum.count(specs) == 1
+
+        assert Enum.at(specs, 0) ==
+                 :poolboy.child_spec(
+                   :worker,
+                   [
+                     {:name, {:local, :ipc_worker}},
+                     {:worker_module, Ethereumex.IpcServer},
+                     {:size, 3},
+                     {:max_overflow, 4}
+                   ],
+                   path: "#{System.user_home!()}/tmp/socket.ipc",
+                   ipc_request_timeout: 5
+                 )
+      end
+    end
+
+    test ":http has no supervised children" do
+      assert Ethereumex.Config.setup_children(:http) == []
+    end
+
+    test "unsupported client types raise an error" do
+      assert_raise(
+        RuntimeError,
+        "Invalid :client option (not_supported) in config",
+        fn ->
+          Ethereumex.Config.setup_children(:not_supported)
+        end
+      )
+    end
+
+    test "defaults to the configured client_type" do
+      with_env put: [ethereumex: [client_type: :http]] do
+        assert Ethereumex.Config.setup_children() == []
+      end
+    end
+  end
+
+  describe ".rpc_url" do
+    test "returns the application configured value" do
+      with_env put: [ethereumex: [url: "http://foo.com"]] do
+        assert Ethereumex.Config.rpc_url() == "http://foo.com"
+      end
+    end
+
+    test "raises an error when not present" do
+      with_env put: [ethereumex: [url: ""]] do
+        assert_raise(
+          ArgumentError,
+          "Please set config variable `config :ethereumex, :url, \"http://...\", got: `\"\"`",
+          fn -> Ethereumex.Config.rpc_url() end
+        )
+      end
+    end
+  end
+
+  describe ".ipc_path" do
+    test "returns the application configured value" do
+      with_env put: [ethereumex: [ipc_path: "/tmp/socket.ipc"]] do
+        assert Ethereumex.Config.ipc_path() == "/tmp/socket.ipc"
+      end
+    end
+
+    test "raises an error when not present" do
+      with_env put: [ethereumex: [ipc_path: ""]] do
+        assert_raise(
+          ArgumentError,
+          "Please set config variable `config :ethereumex, :ipc_path, \"path/to/ipc\", got ``. Note: System.user_home! will be prepended to path for you on initialization",
+          fn -> Ethereumex.Config.ipc_path() end
+        )
+      end
+    end
+  end
+
+  describe ".http_options" do
+    test "returns the application configured value" do
+      with_env put: [ethereumex: [http_options: [timeout: 8000]]] do
+        assert Ethereumex.Config.http_options() == [timeout: 8000]
+      end
+    end
+
+    test "returns an empty list by default" do
+      with_env delete: [ethereumex: [:http_options]] do
+        assert Ethereumex.Config.http_options() == []
+      end
+    end
+  end
+
+  describe ".client_type" do
+    test "returns the application configured value" do
+      with_env put: [ethereumex: [client_type: :ipc]] do
+        assert Ethereumex.Config.client_type() == :ipc
+      end
+    end
+
+    test "returns http by default" do
+      with_env delete: [ethereumex: [:client_type]] do
+        assert Ethereumex.Config.client_type() == :http
+      end
+    end
+  end
+end


### PR DESCRIPTION
- Defaults to the configured client type
- Can be explicitly injected which is helpful for testing
- Add test coverage for `Ethereumex.Config`