### PR TITLE
Added exclamation to Base.decode16

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,8 +204,8 @@ end
 Now load the ABI and pass the method signature. Note that the address needs to be converted to bytes:
 
 ```elixir
-address           = "0x123" |> String.slice(2..-1) |> Base.decode16!(case: :mixed)
-contract_address  = "0x432"
+address           = "0xF742d4cE7713c54dD701AA9e92101aC42D63F895" |> String.slice(2..-1) |> Base.decode16!(case: :mixed)
+contract_address  = "0x489e1C1a467Dc7454A514844094fe265580f8f2e81BA7430f27F657c648ff992"
 abi_encoded_data  = ABI.encode("balanceOf(address)", [address]) |> Base.encode16(case: :lower)
 ```
 

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ end
 Now load the ABI and pass the method signature. Note that the address needs to be converted to bytes:
 
 ```elixir
-address           = "0x123" |> String.slice(2..-1) |> Base.decode16(case: :mixed)
+address           = "0x123" |> String.slice(2..-1) |> Base.decode16!(case: :mixed)
 contract_address  = "0x432"
 abi_encoded_data  = ABI.encode("balanceOf(address)", [address]) |> Base.encode16(case: :lower)
 ```

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ Now load the ABI and pass the method signature. Note that the address needs to b
 
 ```elixir
 address           = "0xF742d4cE7713c54dD701AA9e92101aC42D63F895" |> String.slice(2..-1) |> Base.decode16!(case: :mixed)
-contract_address  = "0x489e1C1a467Dc7454A514844094fe265580f8f2e81BA7430f27F657c648ff992"
+contract_address  = "0xC28980830dD8b9c68a45384f5489ccdAF19D53cC"
 abi_encoded_data  = ABI.encode("balanceOf(address)", [address]) |> Base.encode16(case: :lower)
 ```
 


### PR DESCRIPTION
I have to add exclamation to prevent this error:

** (FunctionClauseError) no function clause matching in ABI.TypeEncoder.maybe_encode_unsigned/1