### PR TITLE
add http_headers as optional param

### DIFF
--- a/lib/ethereumex/http_client.ex
+++ b/lib/ethereumex/http_client.ex
@@ -11,7 +11,7 @@ defmodule Ethereumex.HttpClient do
 
   @spec post_request(binary(), [opt()]) :: {:ok, any()} | http_client_error()
   def post_request(payload, opts) do
-    headers = Config.http_headers()
+    headers = Keyword.get(opts, :http_headers) || Config.http_headers()
     url = Keyword.get(opts, :url) || Config.rpc_url()
     request = Finch.build(:post, url, headers, payload)
 


### PR DESCRIPTION
Issue #96 added support for http headers to be added (for basic auth)
Issue #99 was initially asked for multiple endpoints - however, the solution is to just pass in the URL as an option.

Currently, we don't allow passing in headers as well as the url to auth against multiple different endpoints. I think this is the correct fix. Feedback appreciated.