### PR TITLE
Add EIP1559 support for eth_maxPriorityFeePerGas and eth_feeHistory

### DIFF
--- a/lib/ethereumex/client/base_client.ex
+++ b/lib/ethereumex/client/base_client.ex
@@ -77,8 +77,9 @@ defmodule Ethereumex.Client.BaseClient do
       end
 
       @impl true
-      def eth_fee_history(opts \\ []) do
-        request("eth_feeHistory", [], opts)
+      def eth_fee_history(block_count, newestblock, reward_percentiles, opts \\ []) do
+        params = [block_count, newestblock, reward_percentiles]
+        request("eth_feeHistory", params, opts)
       end
 
       @impl true

--- a/lib/ethereumex/client/base_client.ex
+++ b/lib/ethereumex/client/base_client.ex
@@ -72,6 +72,11 @@ defmodule Ethereumex.Client.BaseClient do
       end
 
       @impl true
+      def eth_max_priority_fee_per_gas(opts \\ []) do
+        request("eth_maxPriorityFeePerGas", [], opts)
+      end
+
+      @impl true
       def eth_accounts(opts \\ []) do
         request("eth_accounts", [], opts)
       end

--- a/lib/ethereumex/client/base_client.ex
+++ b/lib/ethereumex/client/base_client.ex
@@ -77,6 +77,11 @@ defmodule Ethereumex.Client.BaseClient do
       end
 
       @impl true
+      def eth_fee_history(opts \\ []) do
+        request("eth_feeHistory", [], opts)
+      end
+
+      @impl true
       def eth_accounts(opts \\ []) do
         request("eth_accounts", [], opts)
       end

--- a/lib/ethereumex/client/behaviour.ex
+++ b/lib/ethereumex/client/behaviour.ex
@@ -15,6 +15,7 @@ defmodule Ethereumex.Client.Behaviour do
   @callback eth_mining(keyword()) :: {:ok, boolean()} | error
   @callback eth_hashrate(keyword()) :: {:ok, binary()} | error
   @callback eth_gas_price(keyword()) :: {:ok, binary()} | error
+  @callback eth_max_priority_fee_per_gas(keyword()) :: {:ok, binary()} | error
   @callback eth_accounts(keyword()) :: {:ok, [binary()]} | error
   @callback eth_block_number(keyword()) :: {:ok, binary} | error
   @callback eth_get_balance(binary(), binary(), keyword()) :: {:ok, binary()} | error

--- a/lib/ethereumex/client/behaviour.ex
+++ b/lib/ethereumex/client/behaviour.ex
@@ -16,7 +16,7 @@ defmodule Ethereumex.Client.Behaviour do
   @callback eth_hashrate(keyword()) :: {:ok, binary()} | error
   @callback eth_gas_price(keyword()) :: {:ok, binary()} | error
   @callback eth_max_priority_fee_per_gas(keyword()) :: {:ok, binary()} | error
-  @callback eth_fee_history(keyword()) :: {:ok, binary()} | error
+  @callback eth_fee_history(binary(), binary(), list(binary()), keyword()) :: {:ok, map()} | error
   @callback eth_accounts(keyword()) :: {:ok, [binary()]} | error
   @callback eth_block_number(keyword()) :: {:ok, binary} | error
   @callback eth_get_balance(binary(), binary(), keyword()) :: {:ok, binary()} | error

--- a/lib/ethereumex/client/behaviour.ex
+++ b/lib/ethereumex/client/behaviour.ex
@@ -16,6 +16,7 @@ defmodule Ethereumex.Client.Behaviour do
   @callback eth_hashrate(keyword()) :: {:ok, binary()} | error
   @callback eth_gas_price(keyword()) :: {:ok, binary()} | error
   @callback eth_max_priority_fee_per_gas(keyword()) :: {:ok, binary()} | error
+  @callback eth_fee_history(keyword()) :: {:ok, binary()} | error
   @callback eth_accounts(keyword()) :: {:ok, [binary()]} | error
   @callback eth_block_number(keyword()) :: {:ok, binary} | error
   @callback eth_get_balance(binary(), binary(), keyword()) :: {:ok, binary()} | error

--- a/test/ethereumex/client/base_client_test.exs
+++ b/test/ethereumex/client/base_client_test.exs
@@ -96,6 +96,7 @@ defmodule Ethereumex.Client.BaseClientTest do
   test ".eth_hashrate/0", do: Helpers.check("eth_hashrate")
   test ".eth_gas_price/0", do: Helpers.check("eth_gas_price")
   test ".eth_max_priority_fee_per_gas/0", do: Helpers.check("eth_max_priority_fee_per_gas")
+  test ".eth_fee_history/0", do: Helpers.check("eth_fee_history")
   test ".eth_accounts/0", do: Helpers.check("eth_accounts")
   test ".eth_block_number/0", do: Helpers.check("eth_block_number")
   test ".eth_get_compilers/0", do: Helpers.check("eth_get_compilers")

--- a/test/ethereumex/client/base_client_test.exs
+++ b/test/ethereumex/client/base_client_test.exs
@@ -95,6 +95,7 @@ defmodule Ethereumex.Client.BaseClientTest do
   test ".eth_mining/0", do: Helpers.check("eth_mining")
   test ".eth_hashrate/0", do: Helpers.check("eth_hashrate")
   test ".eth_gas_price/0", do: Helpers.check("eth_gas_price")
+  test ".eth_max_priority_fee_per_gas/0", do: Helpers.check("eth_max_priority_fee_per_gas")
   test ".eth_accounts/0", do: Helpers.check("eth_accounts")
   test ".eth_block_number/0", do: Helpers.check("eth_block_number")
   test ".eth_get_compilers/0", do: Helpers.check("eth_get_compilers")

--- a/test/ethereumex/client/base_client_test.exs
+++ b/test/ethereumex/client/base_client_test.exs
@@ -96,7 +96,7 @@ defmodule Ethereumex.Client.BaseClientTest do
   test ".eth_hashrate/0", do: Helpers.check("eth_hashrate")
   test ".eth_gas_price/0", do: Helpers.check("eth_gas_price")
   test ".eth_max_priority_fee_per_gas/0", do: Helpers.check("eth_max_priority_fee_per_gas")
-  test ".eth_fee_history/0", do: Helpers.check("eth_fee_history")
+  test ".eth_fee_history/3", do: Helpers.check("eth_fee_history", [1, "latest", [25, 75]])
   test ".eth_accounts/0", do: Helpers.check("eth_accounts")
   test ".eth_block_number/0", do: Helpers.check("eth_block_number")
   test ".eth_get_compilers/0", do: Helpers.check("eth_get_compilers")

--- a/test/ethereumex/http_client_test.exs
+++ b/test/ethereumex/http_client_test.exs
@@ -114,6 +114,15 @@ defmodule Ethereumex.HttpClientTest do
   end
 
   @tag :eth
+  describe "HttpClient.eth_fee_history/1" do
+    test "returns a collection of historical gas information" do
+      result = HttpClient.eth_fee_history()
+
+      {:ok, <<_::binary>>} = result
+    end
+  end
+
+  @tag :eth
   describe "HttpClient.eth_accounts/1" do
     test "returns addresses owned by client" do
       {:ok, result} = HttpClient.eth_accounts()

--- a/test/ethereumex/http_client_test.exs
+++ b/test/ethereumex/http_client_test.exs
@@ -114,9 +114,9 @@ defmodule Ethereumex.HttpClientTest do
   end
 
   @tag :eth
-  describe "HttpClient.eth_fee_history/1" do
+  describe "HttpClient.eth_fee_history/3" do
     test "returns a collection of historical gas information" do
-      result = HttpClient.eth_fee_history()
+      result = HttpClient.eth_fee_history(1, "latest", [25, 75])
 
       assert is_map(result)
     end

--- a/test/ethereumex/http_client_test.exs
+++ b/test/ethereumex/http_client_test.exs
@@ -118,7 +118,7 @@ defmodule Ethereumex.HttpClientTest do
     test "returns a collection of historical gas information" do
       result = HttpClient.eth_fee_history()
 
-      {:ok, <<_::binary>>} = result
+      assert is_map(result)
     end
   end
 

--- a/test/ethereumex/http_client_test.exs
+++ b/test/ethereumex/http_client_test.exs
@@ -105,6 +105,15 @@ defmodule Ethereumex.HttpClientTest do
   end
 
   @tag :eth
+  describe "HttpClient.eth_max_priority_fee_per_gas/1" do
+    test "returns current max priority fee per gas" do
+      result = HttpClient.eth_max_priority_fee_per_gas()
+
+      {:ok, <<_::binary>>} = result
+    end
+  end
+
+  @tag :eth
   describe "HttpClient.eth_accounts/1" do
     test "returns addresses owned by client" do
       {:ok, result} = HttpClient.eth_accounts()

--- a/test/ethereumex/ipc_client_test.exs
+++ b/test/ethereumex/ipc_client_test.exs
@@ -129,7 +129,7 @@ defmodule Ethereumex.IpcClientTest do
     test "returns a collection of historical gas information" do
       result = IpcClient.eth_fee_history()
 
-      {:ok, <<_::binary>>} = result
+      assert is_map(result)
     end
   end
 

--- a/test/ethereumex/ipc_client_test.exs
+++ b/test/ethereumex/ipc_client_test.exs
@@ -125,9 +125,9 @@ defmodule Ethereumex.IpcClientTest do
   end
 
   @tag :eth
-  describe "IpcClient.eth_fee_history/1" do
+  describe "IpcClient.eth_fee_history/3" do
     test "returns a collection of historical gas information" do
-      result = IpcClient.eth_fee_history()
+      result = IpcClient.eth_fee_history(1, "latest", [25, 75])
 
       assert is_map(result)
     end

--- a/test/ethereumex/ipc_client_test.exs
+++ b/test/ethereumex/ipc_client_test.exs
@@ -125,6 +125,15 @@ defmodule Ethereumex.IpcClientTest do
   end
 
   @tag :eth
+  describe "IpcClient.eth_fee_history/1" do
+    test "returns a collection of historical gas information" do
+      result = IpcClient.eth_fee_history()
+
+      {:ok, <<_::binary>>} = result
+    end
+  end
+
+  @tag :eth
   describe "IpcClient.eth_accounts/1" do
     test "returns addresses owned by client" do
       {:ok, result} = IpcClient.eth_accounts()

--- a/test/ethereumex/ipc_client_test.exs
+++ b/test/ethereumex/ipc_client_test.exs
@@ -116,6 +116,15 @@ defmodule Ethereumex.IpcClientTest do
   end
 
   @tag :eth
+  describe "IpcClient.eth_max_priority_fee_per_gas/1" do
+    test "returns current max priority fee per gas" do
+      result = IpcClient.eth_max_priority_fee_per_gas()
+
+      {:ok, <<_::binary>>} = result
+    end
+  end
+
+  @tag :eth
   describe "IpcClient.eth_accounts/1" do
     test "returns addresses owned by client" do
       {:ok, result} = IpcClient.eth_accounts()


### PR DESCRIPTION
This PR adds support for `eth_maxPriorityFeePerGas` and `eth_feeHistory` which were added during the London fork for EIP1559 support.

[Reference](https://github.com/ethereum/pm/issues/328)