### PR TITLE
Add `eth_blob_base_fee` support

### DIFF
--- a/lib/ethereumex/client/base_client.ex
+++ b/lib/ethereumex/client/base_client.ex
@@ -88,6 +88,11 @@ defmodule Ethereumex.Client.BaseClient do
       end
 
       @impl true
+      def eth_blob_base_fee(opts \\ []) do
+        request("eth_blobBaseFee", [], opts)
+      end
+
+      @impl true
       def eth_accounts(opts \\ []) do
         request("eth_accounts", [], opts)
       end

--- a/lib/ethereumex/client/behaviour.ex
+++ b/lib/ethereumex/client/behaviour.ex
@@ -18,6 +18,7 @@ defmodule Ethereumex.Client.Behaviour do
   @callback eth_gas_price(keyword()) :: {:ok, binary()} | error
   @callback eth_max_priority_fee_per_gas(keyword()) :: {:ok, binary()} | error
   @callback eth_fee_history(binary(), binary(), list(binary()), keyword()) :: {:ok, map()} | error
+  @callback eth_blob_base_fee(keyword()) :: {:ok, binary()} | error
   @callback eth_accounts(keyword()) :: {:ok, [binary()]} | error
   @callback eth_block_number(keyword()) :: {:ok, binary} | error
   @callback eth_get_balance(binary(), binary(), keyword()) :: {:ok, binary()} | error

--- a/test/ethereumex/client/base_client_test.exs
+++ b/test/ethereumex/client/base_client_test.exs
@@ -98,6 +98,7 @@ defmodule Ethereumex.Client.BaseClientTest do
   test ".eth_gas_price/0", do: Helpers.check("eth_gas_price")
   test ".eth_max_priority_fee_per_gas/0", do: Helpers.check("eth_max_priority_fee_per_gas")
   test ".eth_fee_history/3", do: Helpers.check("eth_fee_history", [1, "latest", [25, 75]])
+  test ".eth_blob_base_fee/0", do: Helpers.check("eth_blob_base_fee")
   test ".eth_accounts/0", do: Helpers.check("eth_accounts")
   test ".eth_block_number/0", do: Helpers.check("eth_block_number")
   test ".eth_get_compilers/0", do: Helpers.check("eth_get_compilers")

--- a/test/ethereumex/http_client_test.exs
+++ b/test/ethereumex/http_client_test.exs
@@ -132,6 +132,15 @@ defmodule Ethereumex.HttpClientTest do
   end
 
   @tag :eth
+  describe "HttpClient.eth_blob_base_fee/1" do
+    test "returns the blob base fee of the latest block" do
+      result = HttpClient.eth_blob_base_fee()
+
+      {:ok, <<_::binary>>} = result
+    end
+  end
+
+  @tag :eth
   describe "HttpClient.eth_accounts/1" do
     test "returns addresses owned by client" do
       {:ok, result} = HttpClient.eth_accounts()

--- a/test/ethereumex/ipc_client_test.exs
+++ b/test/ethereumex/ipc_client_test.exs
@@ -142,6 +142,15 @@ defmodule Ethereumex.IpcClientTest do
     end
   end
 
+  @tag :skip
+  describe "IpcClient.eth_blob_base_fee/1" do
+    test "returns the base fee for blob transactions" do
+      result = IpcClient.eth_blob_base_fee()
+
+      {:ok, <<_::binary>>} = result
+    end
+  end
+
   @tag :eth
   describe "IpcClient.eth_accounts/1" do
     test "returns addresses owned by client" do


### PR DESCRIPTION
Adds support for Ethereum `eth_blobBaseFee` JSON RPC action. (As per [this document](https://ethereum.github.io/execution-apis/api-documentation/))